### PR TITLE
accept_exeptionを指定した場合にtimeoutのretryキャッチが出来ない問題を修正

### DIFF
--- a/lib/retry-handler.rb
+++ b/lib/retry-handler.rb
@@ -17,7 +17,7 @@ module RetryHandler
     logger = options[:logger] || Logger.new(nil)
 
     _retry_handler(max, wait, exception, logger) do
-      timeout(timeout, RetryError) do
+      timeout(timeout, exception) do
         block.call
       end
     end

--- a/lib/retry-handler/version.rb
+++ b/lib/retry-handler/version.rb
@@ -1,5 +1,5 @@
 module Retry
   module Handler
-    VERSION = "0.2"
+    VERSION = "0.3"
   end
 end


### PR DESCRIPTION
accept_exceptionにStandardError, もしくはRetryError以外を指定した場合に、
timeout値に到達した際にretryが正常に動作しないバグを修正しました。
