### PR TITLE
Object#timeoutをTimeout#timeoutに修正

### DIFF
--- a/lib/retry-handler.rb
+++ b/lib/retry-handler.rb
@@ -17,7 +17,7 @@ module RetryHandler
     logger = options[:logger] || Logger.new(nil)
 
     _retry_handler(max, wait, exception, logger) do
-      timeout(timeout, RetryError) do
+      Timeout.timeout(timeout, RetryError) do
         block.call
       end
     end


### PR DESCRIPTION
ruby2.3でObject#timeoutがdeprecatedのため、Timeout#timeoutに修正しました。

```
ruby/gems/2.3.0/gems/retry-handler-0.2/lib/retry-handler.rb:20:in `block in retry_handler': Object#timeout is deprecated, use Timeout.timeout instead.
```